### PR TITLE
Update scala.js and scalajs-bundler

### DIFF
--- a/src/main/g8/project/plugins.sbt
+++ b/src/main/g8/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.19")
-addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.6.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.20")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.9.0")


### PR DESCRIPTION
Scala.js bundler 0.6.0 was incompatible with the latest version of webpack.