### PR TITLE
update template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@ boot/
 lib_managed/
 src_managed/
 project/plugins/project/
-
+.idea/
 .DS_STORE

--- a/src/main/g8/.gitignore
+++ b/src/main/g8/.gitignore
@@ -1,1 +1,2 @@
 target/
+.idea/

--- a/src/main/g8/README.md
+++ b/src/main/g8/README.md
@@ -1,0 +1,16 @@
+$name$
+====
+
+## Create a module
+in sbt shell: `fastOptJS::webpack` or `fullOptJS::webpack`
+
+## Working in dev mode
+In sbt shell, run `dev`. Then open `http://localhost:8080/` in your browser.
+
+This sbt-task will start webpack dev server, compile your code each time it changes
+and auto-reload the page.  
+webpack dev server will close automatically when you stop the `dev` task
+(e.g by hitting `Enter` in the sbt shell while you are in `dev` watch mode).
+
+If you existed ungracefully and your webpack dev server is still open (check with `ps -aef | grep -v grep | grep webpack`),
+you can close it by running `fastOptJS::stopWebpackDevServer` in sbt.

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -1,3 +1,5 @@
+import org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv
+
 organization := "$organization$"
 name := "$name;format="Camel"$"
 version := "$version$"
@@ -9,11 +11,12 @@ libraryDependencies ++= Seq(
   "org.scalatest" %%% "scalatest" % "3.0.5" % Test
 )
 
-enablePlugins(ScalaJSPlugin, ScalaJSBundlerPlugin)
+enablePlugins(ScalaJSBundlerPlugin)
 scalacOptions += "-P:scalajs:sjsDefinedByDefault"
 useYarn := true // makes scalajs-bundler use yarn instead of npm
-requiresDOM in Test := true
+jsEnv in Test := new JSDOMNodeJSEnv
 scalaJSUseMainModuleInitializer := true
+scalaJSModuleKind := ModuleKind.CommonJSModule // configure Scala.js to emit a JavaScript module instead of a top-level script
 
 
 scalacOptions ++=

--- a/src/main/g8/webpack.config.dev.js
+++ b/src/main/g8/webpack.config.dev.js
@@ -11,6 +11,6 @@ module.exports.devServer = {
     ],
     watchContentBase: true,
     hot: false,
-    hotOnly: false, // only reload when build is sucessful
+    hotOnly: false, // only reload when build is successful
     inline: true // show build errors in browser console
 };


### PR DESCRIPTION
1. fix deprecation for requiresDOM in Test
2. add scalaJSModuleKind := ModuleKind.CommonJSModule // configure Scala.js to emit a JavaScript module instead of a top-level script
3. only enable ScalaJSBundlerPlugin plugin (to make build.sbt a bit simpler). It automatically enables ScalaJSPlugin.
4. add a small README.md to the generated project, describing how to get started.