### PR TITLE
Add prerequisites to the readme

### DIFF
--- a/src/main/g8/README.md
+++ b/src/main/g8/README.md
@@ -1,6 +1,13 @@
 $name$
 ====
 
+## Prerequisites
+   
+You should make sure that the following components are pre-installed on your machine:
+   
+ - [Node.js](https://nodejs.org/en/download/)
+ - [Yarn](https://yarnpkg.com/en/docs/install)
+
 ## Create a module
 in sbt shell: `fastOptJS::webpack` or `fullOptJS::webpack`
 


### PR DESCRIPTION
In order to make the readme a bit more user friendly to new developers.

Based on [scala.js prerequisites](https://www.scala-js.org/tutorial/basic/index.html) and the [note in Yarn section](https://scalacenter.github.io/scalajs-bundler/reference.html#yarn) in scalajs-bundler.