### PR TITLE
optionally emit source maps and copy them to /dev

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -44,6 +44,8 @@ scalacOptions ++=
 addCommandAlias("dev", "; compile; fastOptJS::startWebpackDevServer; devwatch; fastOptJS::stopWebpackDevServer")
 addCommandAlias("devwatch", "~; fastOptJS; copyFastOptJS")
 
+emitSourceMaps := false
+
 version in webpack := "4.16.1"
 version in startWebpackDevServer := "3.1.4"
 webpackDevServerExtraArgs := Seq("--progress", "--color")
@@ -59,6 +61,11 @@ lazy val copyFastOptJS = TaskKey[Unit]("copyFastOptJS", "Copy javascript files t
 copyFastOptJS := {
   val inDir = (crossTarget in (Compile, fastOptJS)).value
   val outDir = (crossTarget in (Compile, fastOptJS)).value / "dev"
-  val files = Seq(name.value.toLowerCase + "-fastopt-loader.js", name.value.toLowerCase + "-fastopt.js") map { p => (inDir / p, outDir / p) }
+  val fileNames = Seq(name.value.toLowerCase + "-fastopt-loader.js", name.value.toLowerCase + "-fastopt.js")
+  val files = (
+    if (emitSourceMaps.value) fileNames :+ name.value.toLowerCase + "-fastopt.js.map" else fileNames
+  ) map { p =>
+    (inDir / p, outDir / p)
+  }
   IO.copy(files, overwrite = true, preserveLastModified = true, preserveExecutable = true)
 }


### PR DESCRIPTION
Closes #7

Enabling the config option increases turn around times by ~20 seconds.  
I do not advise enabling this config option unless absolutely necessary. Thus I have disabled it by default. If the `emitSourceMaps` setting is set, the copy task automatically copies the latest generated source map over.  

Sometimes it may be necessary to run `sbt clean` before enabling the setting, but I could not figure out why.  

There is also an option added by scalajs-bundler for enabling webpack sourcemaps `webpackEmitSourceMaps`, but it should follow the scalajs setting by default.

Fun-Fact:
ScalaJS bundles the entirety of the projects libraries in the source-maps.
The source maps get so big that Firefox devs use them to performance test their source-map parsers.  
https://hacks.mozilla.org/2018/01/oxidizing-source-maps-with-rust-and-webassembly/