### PR TITLE
Update to scala 2.13

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -2,11 +2,11 @@ organization := "$organization$"
 name := "$name;format="Camel"$"
 version := "$version$"
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.13.0"
 resolvers += "jitpack" at "https://jitpack.io"
 
 libraryDependencies ++= Seq(
-  "com.github.outwatch" % "outwatch" % "401158d",
+  "com.github.outwatch.outwatch" %%% "outwatch" % "a332851",
   "org.scalatest" %%% "scalatest" % "3.0.8" % Test
 )
 


### PR DESCRIPTION
Changes `build.sbt` to use `%%%` in the outwatch dependency definition.  
Increments the scala version to `2.13`.  

I personally think the seed project should use `2.13` since we support it and overall support of the ecosystem is getting quite good, since the new cats and monix releases recently.  